### PR TITLE
Option to create branch in destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This GitHub Action copies a folder from the current repository to a location in 
 * user_email: The GitHub user email associated with the API token secret.
 * user_name: The GitHub username associated with the API token secret.
 * destination_branch: [optional] The branch of the source repo to update, if not master.
+* destination_branch_create: [optional] A branch to be created with this commit, defaults to commiting in `destination_branch`
 * commit_msg: [optional] The commit message to use.
 
 # Behavior Notes

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   commit_msg:
     description: 'The commit message'
     required: false
+  destination_branch_create:
+    description: 'Destination branch to create for this commit'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -31,6 +34,7 @@ runs:
     - ${{ inputs.destination-folder }}
     - ${{ inputs.user-email }}
     - ${{ inputs.destination-branch }}
+    - ${{ inputs.destination-branch-create }}
     - ${{ inputs.commit_msg }}
 branding:
   icon: 'git-commit'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,7 @@ if [ -z "$INPUT_DESTINATION_BRANCH" ]
 then
   INPUT_DESTINATION_BRANCH=master
 fi
+OUTPUT_BRANCH="$INPUT_DESTINATION_BRANCH"
 
 if [ -z "$INPUT_COMMIT_MSG" ]
 then
@@ -26,6 +27,12 @@ git config --global user.email "$INPUT_USER_EMAIL"
 git config --global user.name "$INPUT_USER_NAME"
 git clone --single-branch --branch $INPUT_DESTINATION_BRANCH "https://$API_TOKEN_GITHUB@github.com/$INPUT_DESTINATION_REPO.git" "$CLONE_DIR"
 
+if [ ! -z "$INPUT_DESTINATION_BRANCH_CREATE" ]
+then
+  git checkout -b "$INPUT_DESTINATION_BRANCH_CREATE"
+  OUTPUT_BRANCH="$INPUT_DESTINATION_BRANCH_CREATE"
+fi
+
 echo "Copying contents to git repo"
 rm -rf $CLONE_DIR/$INPUT_DESTINATION_FOLDER/
 cp -a $INPUT_SOURCE_FOLDER/. $CLONE_DIR/$INPUT_DESTINATION_FOLDER/
@@ -37,7 +44,7 @@ if git status | grep -q "Changes to be committed"
 then
   git commit --message "$INPUT_COMMIT_MSG"
   echo "Pushing git commit"
-  git push origin $INPUT_DESTINATION_BRANCH
+  git push -u origin HEAD:$OUTPUT_BRANCH
 else
   echo "No changes detected"
 fi


### PR DESCRIPTION
Cherry picked from https://github.com/dmnemec/copy_file_to_another_repo_action/pull/1

This is a feature that would be useful to me when copying a folder using this action, as I typically push to a non-default branch, create a PR, then delete the branch after merging.

Thanks for creating and maintaining this action! ❤️ 